### PR TITLE
Add Org-Level Community Health Files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# 1Password Community Code of Conduct
+The Passage by 1Password GitHub exists to facilitate information sharing and deliver resources to developers who are interested in Passage products.
+
+We want to encourage an environment that is friendly, safe, accepting, and free from intimidation and harassment.
+
+To this end, certain behaviors and practices will not be tolerated.
+
+> [!TL;DR]
+> - Be respectful
+> - No solicitation
+> - Abusive behavior is never tolerated
+>
+> Our community administrators are here to help:
+> - [Sara Teare (Co-founder)](https://1password-devs.slack.com/team/U032CAY0DAB)
+> - [Michael Carey](https://1password-devs.slack.com/team/U03KJ86AUS3)
+>
+> Violations of this code may result in swift and permanent expulsion from the Passage GitHub Community.
+
+# Scope
+We expect all members of the Passage GitHub Community — including administrators, users, facilitators, and vendors — to abide by this Code of Conduct at all times. This Code of Conduct applies in all 1Password Developer community venues, both online and in person, including all public and private channels and one-on-one communications pertaining to 1Password Developer affairs.
+
+This policy covers the usage of the Passage GitHub Community as well as both online and in-person events.
+
+This Code of Conduct is in addition to, and does not in any way nullify or invalidate, any other terms or conditions related to use of the Passage GitHub Community.
+
+The definitions of various subjective terms such as "discriminatory", "hateful", or "confusing" will be decided at the sole discretion of the 1Password Developer community administrators.
+
+# Friendly, Harassment-Free Space
+We are committed to providing a friendly, safe, and welcoming environment for all, regardless of gender identity, sexual orientation, disability, ethnicity, religion, age, physical appearance, body size, race, or similar personal characteristics.
+
+We ask that you respect that people have differences of opinion regarding technical choices, and acknowledge that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer. A difference of technology preferences is never a license to be rude.
+
+Any spamming, trolling, flaming, baiting, or other attention-stealing behavior is not welcome, and will not be tolerated.
+
+Harassing other users of the Passage GitHub Community is never tolerated, whether via public or private media.
+
+Avoid using offensive or harassing package names, nicknames, or other identifiers that might detract from a friendly, safe, and welcoming environment for all. Harassment includes, but is not limited to: harmful or prejudicial verbal or written comments related to gender identity, sexual orientation, disability, ethnicity, religion, age, physical appearance, body size, race, or similar personal characteristics; inappropriate use of nudity, sexual images, and/or sexually explicit language in public spaces; threats of physical or non-physical harm; deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; and unwelcome sexual attention.
+
+# Reporting Violations of this Code of Conduct
+If you believe someone is harassing you or has otherwise violated this Code of Conduct, please contact any of the administrators listed at the top of this document and send us an abuse report. If this is the initial report of a problem, please include as much detail as possible. It is easiest for us to address issues when we have more context.
+
+# Consequences
+All content published to the Passage GitHub Community, including user account credentials, is hosted at the sole discretion of the 1Password Developer community administrators.
+
+Unacceptable behavior from any community member, including employees, customers, or others with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the 1Password Developer community administrators may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event or service).
+
+# Addressing Grievances
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, please notify the 1Password Developers Slack Community admin team either by posting in [`#moderators`](https://1password-devs.slack.com/archives/C0331DJL882) or reaching out privately via DM to any of the administrators listed at the top of this document.
+
+We will do our best to ensure that your grievance is handled appropriately.
+
+In general, we will choose the course of action that we judge as being most in the interest of fostering a safe and friendly community.
+
+# Contact Information
+Please contact any of the administrators listed at the top of this document if you need to report a problem or address a grievance related to an abuse report.
+
+You're encouraged to contact the admin team in cases where you're unsure if something is or isn't appropriate content. We are happy to provide guidance to help you be a successful part of our community.
+
+# Learn More
+Learn more at the [1Password Developer Community](https://developer.1password.com/code-of-conduct/).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,9 +10,8 @@ To this end, certain behaviors and practices will not be tolerated.
 - No solicitation
 - Abusive behavior is never tolerated
 
-Our community administrators are here to help:
-- [Sara Teare (Co-founder)](https://1password-devs.slack.com/team/U032CAY0DAB)
-- [Michael Carey](https://1password-devs.slack.com/team/U03KJ86AUS3)
+Reach out to Passage support for help:
+- support@passage.id
 
 Violations of this code may result in swift and permanent expulsion from the Passage GitHub Community.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@ We want to encourage an environment that is friendly, safe, accepting, and free 
 
 To this end, certain behaviors and practices will not be tolerated.
 
-> [!TL;DR]
+> [!TIP]
 > - Be respectful
 > - No solicitation
 > - Abusive behavior is never tolerated

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,16 +5,16 @@ We want to encourage an environment that is friendly, safe, accepting, and free 
 
 To this end, certain behaviors and practices will not be tolerated.
 
-> [!TIP]
-> - Be respectful
-> - No solicitation
-> - Abusive behavior is never tolerated
->
-> Our community administrators are here to help:
-> - [Sara Teare (Co-founder)](https://1password-devs.slack.com/team/U032CAY0DAB)
-> - [Michael Carey](https://1password-devs.slack.com/team/U03KJ86AUS3)
->
-> Violations of this code may result in swift and permanent expulsion from the Passage GitHub Community.
+## TL;DR
+- Be respectful
+- No solicitation
+- Abusive behavior is never tolerated
+
+Our community administrators are here to help:
+- [Sara Teare (Co-founder)](https://1password-devs.slack.com/team/U032CAY0DAB)
+- [Michael Carey](https://1password-devs.slack.com/team/U03KJ86AUS3)
+
+Violations of this code may result in swift and permanent expulsion from the Passage GitHub Community.
 
 # Scope
 We expect all members of the Passage GitHub Community — including administrators, users, facilitators, and vendors — to abide by this Code of Conduct at all times. This Code of Conduct applies in all 1Password Developer community venues, both online and in person, including all public and private channels and one-on-one communications pertaining to 1Password Developer affairs.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ Harassing other users of the Passage GitHub Community is never tolerated, whethe
 Avoid using offensive or harassing package names, nicknames, or other identifiers that might detract from a friendly, safe, and welcoming environment for all. Harassment includes, but is not limited to: harmful or prejudicial verbal or written comments related to gender identity, sexual orientation, disability, ethnicity, religion, age, physical appearance, body size, race, or similar personal characteristics; inappropriate use of nudity, sexual images, and/or sexually explicit language in public spaces; threats of physical or non-physical harm; deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; and unwelcome sexual attention.
 
 # Reporting Violations of this Code of Conduct
-If you believe someone is harassing you or has otherwise violated this Code of Conduct, please contact any of the administrators listed at the top of this document and send us an abuse report. If this is the initial report of a problem, please include as much detail as possible. It is easiest for us to address issues when we have more context.
+If you believe someone is harassing you or has otherwise violated this Code of Conduct, please contact the Passage support team at support@passage.id and send us an abuse report. If this is the initial report of a problem, please include as much detail as possible. It is easiest for us to address issues when we have more context.
 
 # Consequences
 All content published to the Passage GitHub Community, including user account credentials, is hosted at the sole discretion of the 1Password Developer community administrators.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,4 +60,4 @@ Please contact the Passage support team at support@passage.id if you need to rep
 You're encouraged to contact the admin team in cases where you're unsure if something is or isn't appropriate content. We are happy to provide guidance to help you be a successful part of our community.
 
 # Learn More
-Learn more at the [1Password Developer Community](https://developer.1password.com/code-of-conduct/).
+Passage by 1Password has more resources at our larger [1Password Developer Community](https://developer.1password.com/code-of-conduct/).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -48,7 +48,7 @@ Anyone asked to stop unacceptable behavior is expected to comply immediately.
 If a community member engages in unacceptable behavior, the 1Password Developer community administrators may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event or service).
 
 # Addressing Grievances
-If you feel you have been falsely or unfairly accused of violating this Code of Conduct, please notify the 1Password Developers Slack Community admin team either by posting in [`#moderators`](https://1password-devs.slack.com/archives/C0331DJL882) or reaching out privately via DM to any of the administrators listed at the top of this document.
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, please notify the Passage Support Team at support@passage.id.
 
 We will do our best to ensure that your grievance is handled appropriately.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ We will do our best to ensure that your grievance is handled appropriately.
 In general, we will choose the course of action that we judge as being most in the interest of fostering a safe and friendly community.
 
 # Contact Information
-Please contact any of the administrators listed at the top of this document if you need to report a problem or address a grievance related to an abuse report.
+Please contact the Passage support team at support@passage.id if you need to report a problem or address a grievance related to an abuse report.
 
 You're encouraged to contact the admin team in cases where you're unsure if something is or isn't appropriate content. We are happy to provide guidance to help you be a successful part of our community.
 

--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Device (please complete the following information):**
+ - Device: [e.g. iPhone 16, Pixel 9 Pro Fold, M3 MacBook Air, Linux Desktop]
+ - OS: [e.g. macOS 14.7, Android 12, iOS 18.1]
+ - Browser: [e.g. Chrome, Safari] (if applicable)
+ - Browser version: [e.g. 129] (if applicable)
+
+**Passage SDK Versions**
+Versions of all Passage SDKs being used in your application. For example:
+- Passage-Node v2.11.0
+- Passage-Elements v1.0.2
+- Passage-Swift v1.0.0
+
+**Third-Party SDK Versions**
+Versions of third-party SDKs relevant to this issue. For example:
+- Next.js 14.2
+- Node 22.9.0
+- React Native 0.75
+
+**Additional context**
+Add any other context about the problem here.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -28,14 +28,6 @@ Please attach any screenshots that would help illustrate the changes.
 - [ ] New and existing integration and unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
 
-
-## Jira Ticket (Internal Only)
-
-Please add the Jira ticket number and link.
-
-- [ ] Jira Ticket: [PSG-XXXX](https://passage-identity.atlassian.net/browse/PSG-XXXX)
-
-
 ## Additional context
 
 Add any other context or screenshots about the pull request here.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!-- You can erase any parts of this template not applicable to your Pull Request. -->
+
+## What's New?
+
+Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+
+## Screenshots (if appropriate):
+
+Please attach any screenshots that would help illustrate the changes.
+
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have manually tested my code thoroughly
+- [ ] I have added/updated inline documentation for public facing interfaces if relevant
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing integration and unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+
+## Jira Ticket (Internal Only)
+
+Please add the Jira ticket number and link.
+
+- [ ] Jira Ticket: [PSG-XXXX](https://passage-identity.atlassian.net/browse/PSG-XXXX)
+
+
+## Additional context
+
+Add any other context or screenshots about the pull request here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+<p align="center">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://storage.googleapis.com/passage-docs/github-md-assets/passage-by-1password-dark.png">
+      <source media="(prefers-color-scheme: light)" srcset="https://storage.googleapis.com/passage-docs/github-md-assets/passage-by-1password-light.png">
+      <img alt="Passage by 1Password Logo" src="https://storage.googleapis.com/passage-docs/github-md-assets/passage-by-1password-light.png">
+    </picture>
+</p>
+
+# Security
+
+[Passage by 1Password](https://1password.com/product/passage) was founded on the principles of providing security and privacy for everyone on the internet. As security experts ourselves, we make an uncompromising commitment to take security within our own products seriously.
+
+### Reporting
+We appreciate efforts to responsibly disclose any of your findings.
+
+To report a security issue or concern, please contact the [Passage by 1Password Security Team](mailto:security@passage.id).
+
+Thank you for helping us build a safer, simpler digital future for everyone.
+
+<br />
+
+---
+
+<p align="center">
+    <sub><a href="https://support.1password.com/security-assessments/">Learn more about Security at 1Password</a></sub><br />
+    <sub><a href="mailto:support@passage.id">support@passage.id</a> | <a href="mailto:security@passage.id">security@passage.id</a>
+</p>

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -62,7 +62,7 @@ We're always eager to chat! Whether you're looking for a demo or just have some 
 * [Blog](https://passage.1password.com/blog)
 * [Console](https://console.passage.id)
 * [Status](https://status.passage.id/)
-* [Security]()
+* [Security](./SECURITY.md)
 
 
 ## Looking for 1Password support?

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,77 @@
+<p align="center">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://storage.googleapis.com/passage-docs/github-md-assets/passage-by-1password-dark.png">
+      <source media="(prefers-color-scheme: light)" srcset="https://storage.googleapis.com/passage-docs/github-md-assets/passage-by-1password-light.png">
+      <img alt="Passage by 1Password Logo" src="https://storage.googleapis.com/passage-docs/github-md-assets/passage-by-1password-light.png">
+    </picture>
+</p>
+
+# Support
+
+[Passage by 1Password](https://1password.com/product/passage) unlocks the passwordless future with a simpler, more secure passkey authentication experience. Passage handles the complexities of the [WebAuthn API](https://blog.1password.com/what-is-webauthn/), and allows you to implement passkeys with ease. 
+
+We're here to help!
+
+## Get in Touch
+![Static Badge](https://img.shields.io/badge/Discord-%235865F2?logo=discord&logoColor=white) <br />
+<span>
+  Join our Discord server to chat with our team directly and become a part of the Passage community.
+  <a href="https://discord.com/invite/445QpyEDXh">Join Discord →</a>
+</span>
+
+![Static Badge](https://img.shields.io/badge/support%40passage.id-%233B66BC?logo=1Password&logoColor=white) <br />
+<span>
+  Send an email to support@passage.id and we'll respond to your inquiry as soon as possible.
+  <a href="mailto:support@passage.id">Email Passage →</a>
+</span>
+
+![Static Badge](https://img.shields.io/badge/GitHub-%23181717?logo=github&logoColor=white) <br />
+<span>
+  Open an issue on any of our GitHub repositories and we'll repond to your inquiry as soon as possible.
+</span>
+
+## Browse our Documentation
+Explore our products and determine how you want to start using Passage by 1Password at [docs.passage.id](https://docs.passage.id). Each product has a rich documentation presence with code snippets and guides to help you find all of the resources you need to easily integrate Passage.
+
+<p>
+    <img src="https://storage.googleapis.com/passage-docs/github-md-assets/passage-passkey-flex-icon.png"> Passkey <b>Flex</b><br />
+    <b>Add passkeys to an existing auth solution:</b>
+    Upgrade your existing authentication flow to support passkeys. With Passkey Flex, you can choose how you incorporate passkeys: as an alternative to passwords at login and registration, as a multi-factor authentication method, or allow users to add a passkey to an existing account.
+    <a href="https://docs.passage.id/flex">Passkey Flex Docs →</a>
+</p>
+
+<p>
+    <img src="https://storage.googleapis.com/passage-docs/github-md-assets/passage-passkey-complete-icon.png"> Passkey <b>Complete</b><br />
+    <b>Use Passage as a standalone auth solution:</b>
+    Replace your existing authentication flow or build from scratch with a robust solution for passwordless authentication and customer identity management. In addition to passkeys, you can add other authentication methods including social sign-in, Magic Links, and one-time codes.
+    <a href="https://docs.passage.id/complete">Passkey Complete Docs →</a>
+</p>
+
+<p>
+    <img src="https://storage.googleapis.com/passage-docs/github-md-assets/passage-passkey-ready-icon.png"> Passkey <b>Ready</b> <br />
+    <b>Determine if your users are ready for passkeys:</b>
+    Add a few lines of code to your app or website and Passkey Ready will generate data to determine if your end users are ready for passkeys.
+    <a href="https://docs.passage.id/passkey-ready">Passkey Ready Docs →</a>
+</p>
+
+## Request a Demo
+We're always eager to chat! Whether you're looking for a demo or just have some questions about our products, please [reach out](https://passage.1password.com/contact) and we’ll be in touch shortly.
+
+## Additional Resources
+
+* [Blog](https://passage.1password.com/blog)
+* [Console](https://console.passage.id)
+* [Status](https://status.passage.id/)
+* [Security]()
+
+
+## Looking for 1Password support?
+Our team is focused on the Passage products, but [1Password Support](https://support.1password.com/) should send you in the right direction!
+
+<br />
+
+---
+
+<p align="center">
+    <sub>Passage is a product by <a href="https://1password.com/product/passage">1Password</a>, the global leader in access management solutions with nearly 150k business customers.</sub>
+</p>


### PR DESCRIPTION
## What's New?

Added the following files and templates:
- Code of Conduct (adapted from https://developer.1password.com/code-of-conduct/)
- Security.md (Provided by Amy)
- Support.md (Provided by Amy)
- PR Template (Based on Passage-Swift, it was my favorite)
- Issue Template (New, based on GitHub recommendations plus some Passage-specific things)